### PR TITLE
correct R2 to R1 mapping in config.ini

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -95,7 +95,7 @@ model_prefix_s3 = pretrained-models/smooth.pkl ; s3 prefix of the pre-trained mo
 ; change reduction_method_ref to reflect desired reduction method
 ; i.e. FROM/ ${reduction.fps_bitrate:method_directory}  TO/  ${reduction.fastsrgan:method_directory}
 #########################
-reduction_method_ref = ${reduction.fps_bitrate:method_directory}
+reduction_method_ref = ${reduction.ffmpeg_resolution_downsampler:method_directory}
 
 ; method specific parameters:
 codec = mp4v ; desired video codec
@@ -118,7 +118,7 @@ model_prefix_s3 = pretrained-models/fastsrgan.h5 ; s3 prefix of the pre-trained 
 ; change reduction_method_ref to reflect desired reduction method
 ; i.e. FROM/ ${reduction.fps_bitrate:method_directory}  TO/  ${reduction.fastsrgan:method_directory}
 #########################
-reduction_method_ref = ${reduction.fps_bitrate:method_directory}
+reduction_method_ref = ${reduction.ffmpeg_resolution_downsampler:method_directory}
 
 ; method specific parameters:
 codec = mp4v ; desired video codec
@@ -139,7 +139,7 @@ output_prefix_s3 = reconstructed-videos/${method_name}-codec_${codec}-resolution
 ; change reduction_method_ref to reflect desired reduction method
 ; i.e. FROM/ ${reduction.fps_bitrate:method_directory}  TO/  ${reduction.fastsrgan:method_directory}
 #########################
-reduction_method_ref = ${reduction.fps_bitrate:method_directory}
+reduction_method_ref = ${reduction.ffmpeg_resolution_downsampler:method_directory}
 
 ; method specific parameters:
 codec = mp4v ; desired video codec
@@ -162,7 +162,7 @@ model_prefix_s3 = pretrained-models/realbasicvsr_x4.pth ; s3 prefix of the pre-t
 ; change reduction_method_ref to reflect desired reduction method
 ; i.e. FROM/ ${reduction.fps_bitrate:method_directory}  TO/  ${reduction.fastsrgan:method_directory}
 #########################
-reduction_method_ref = ${reduction.fps_bitrate:method_directory}
+reduction_method_ref = ${reduction.ffmpeg_resolution_downsampler:method_directory}
 
 ; method specific parameters:
 codec = mp4v ; desired video codec


### PR DESCRIPTION
Corrects mapping from R2 (Reconstruction) to R1 (Reduction) methods in the config.ini file to reflect what is documented in the README as compatible methods.